### PR TITLE
Add write to file and --num_to_show option. README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,35 @@
 This script is a modified version of scripts originally from:
 https://github.com/lightvector/leela-analysis
 
-Currently, it's designed to work with Leela 0.10.0, no guarantees about compatibility with any past or future versions. It runs on python3.
+Currently, it's designed to work with **Leela 0.10.0**, no guarantees about compatibility with any past or future versions. 
+It runs on Python 3.
 
-WARNING: It is not uncommon for Leela to mess up on tactical situations and give poor suggestions, particularly when it hasn't
+**WARNING:** It is not uncommon for Leela to mess up on tactical situations and give poor suggestions, particularly when it hasn't
 realized the life or death of a group yet that is actually already alive or dead. Like all MC bots, it also has a somewhat different
 notion than humans of how to wrap up a won game and what moves (despite still being winning) are "mistakes". Take the analysis with
 many grains of salt.
 
 ### How to Use
-First, download and install the "engine only"/"commandline"/"GTP" version of Leela 0.10.0 from:
+First, download and install the commandline/GTP engine version of Leela from:
 https://sjeng.org/leela.html
 
-Clone this repository to a local directory:
+Download or Clone this repository to a local directory:
 
-    git clone https://github.com/lightvector/leela-analysis
-    cd leela-analysis
+    git clone https://github.com/jumpman24/leela-analysis-36
+    cd leela-analysis-36
 
-Then simply run the script to analyze a game, providing the command to run to the leela executable, such as ./Leela0100GTP.exe or ./leela_0100_linux_x64.
+Then simply run the script to analyze a game, providing the command to run to the leela executable, such as ./Leela0100GTP.exe or ./leela_0100_linux_x64, etc.
 
-    sgfanalyze.py my_game.sgf --leela /PATH/TO/LEELA.exe > my_game_analyzed.sgf
+    sgfanalyze.py my_game.sgf my_game_analyzed.sgf --leela /PATH/TO/LEELA.exe
+
+Some of available options:
+
+    --secs-per-search - How many seconds to use per search (default=10)
+    --var-thresh      - Explore variations on moves losing at least this much of win rate (default=0.03)
+    --analyze-thresh  - Display analysis on moves losing at least this much of win rate (default=0.03)    
+    --nodes-per-var   - Number of nodes to explore (depth) in each variation tree (default=8)
+    --num_to_show     - Number of moves to show in addition to nodes-per-var, helps to clean-up irrational variations (default=2) 
+    --wipe-comments   - Remove existing comments from the main line of the SGF file
 
 By default, Leela will go through every position in the provided game and find what it considers to be all the mistakes by both players,
 producing an SGF file where it highlights those mistakes and provides alternative variations it would have expected. It will probably take

--- a/README.md
+++ b/README.md
@@ -41,14 +41,17 @@ an hour or two to run.
 Run the script with --help to see other options you can configure. You can change the amount of time Leela will analyze for, change how
 much effort it puts in to making variations versus just analyzing the main game, or select just a subrange of the game to analyze.
 
-TODO list:
+
+### TODO list:
 
    - [ ] clean-up suggested variations with low visits rate
    - [ ] mark by A-B alternatives which has low difference
    - [ ] support Ray bot
    - [ ] code refactoring 
    - [ ] add documentation
-   - [ ] update pdf graph output to have better look
+   - [х] update pdf graph output to have better look
+
+___
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Some of available options:
     --var-thresh      - Explore variations on moves losing at least this much of win rate (default=0.03)
     --analyze-thresh  - Display analysis on moves losing at least this much of win rate (default=0.03)    
     --nodes-per-var   - Number of nodes to explore (depth) in each variation tree (default=8)
-    --num_to_show     - Number of moves to show in addition to nodes-per-var, helps to clean-up irrational variations (default=2) 
+    --num_to_show     - Number of moves to show in addition to nodes-per-var, 
+                        helps to clean-up irrational variations (default=2) 
     --wipe-comments   - Remove existing comments from the main line of the SGF file
 
 By default, Leela will go through every position in the provided game and find what it considers to be all the mistakes by both players,

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ an hour or two to run.
 Run the script with --help to see other options you can configure. You can change the amount of time Leela will analyze for, change how
 much effort it puts in to making variations versus just analyzing the main game, or select just a subrange of the game to analyze.
 
+TODO list:
+
+   - [ ] clean-up suggested variations with low visits rate
+   - [ ] mark by A-B alternatives which has low difference
+   - [ ] support Ray bot
+   - [ ] code refactoring 
+   - [ ] add documentation
+   - [ ] update pdf graph output to have better look
+
 ### Troubleshooting
 
 If you get an "OSError: [Errno 2] No such file or directory" error or you get an "OSError: [Errno 8] Exec format error" originating from "subprocess.py",

--- a/sgfanalyze.py
+++ b/sgfanalyze.py
@@ -7,6 +7,7 @@ import math
 from sgftools import gotools, leela, annotations, progressbar, sgflib
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
 
 DEFAULT_STDEV = 0.22
 RESTART_COUNT = 1
@@ -26,18 +27,33 @@ def graph_winrates(winrates, color, outp_fn):
     for move_num in sorted(winrates.keys()):
         pl, wr = winrates[move_num]
 
-        if pl != color:
-            wr = 1.0 - wr
         x.append(move_num)
         y.append(wr)
 
     plt.figure(1)
-    plt.axhline(0.5, 0, max(winrates.keys()), linestyle='--', color='0.7')
-    plt.plot(x, y, color='k', marker='+')
+
+    # fill graph with horizontal coordinate lines, step 0.25
+    for xc in np.arange(0.2, 0.8, 0.025):
+        plt.axhline(xc, 0, max(winrates.keys()), linewidth=0.04, color='0.7')
+
+    # add single central horizontal line
+    plt.axhline(0.50, 0, max(winrates.keys()), linewidth=0.3, color='0.2')
+
+    # main graph of win rate changes
+    plt.plot(x, y, color='#ff0000', marker='.', markersize=2.5, linewidth=0.6)
+
+    # set range limits for x and y axes
     plt.xlim(0, max(winrates.keys()))
-    plt.ylim(0, 1)
-    plt.xlabel("Move Number", fontsize=28)
-    plt.ylabel("Win Rate", fontsize=28)
+    plt.ylim(0.2, 0.8)
+
+    # set size of numbers on axes
+    plt.yticks(np.arange(0.2, 0.8, 0.05),fontsize=6)
+    plt.yticks(fontsize=6)
+
+    # add labels to axes
+    plt.xlabel("Move Number", fontsize=12)
+    plt.ylabel("Win Rate", fontsize=14)
+
     plt.savefig(outp_fn, dpi=200, format='pdf', bbox_inches='tight')
 
 

--- a/sgfanalyze.py
+++ b/sgfanalyze.py
@@ -11,6 +11,11 @@ import matplotlib.pyplot as plt
 DEFAULT_STDEV = 0.22
 RESTART_COUNT = 1
 
+def write_to_file(file, mode, content):
+    with open(file, mode) as f:
+        f.write(str(content))
+
+
 
 def graph_winrates(winrates, color, outp_fn):
     mpl.use('Agg')
@@ -537,6 +542,7 @@ if __name__ == '__main__':
         leela.start()
         add_moves_to_leela(C, leela)
 
+        # analyze main line, without variations
         while not C.atEnd:
             C.next()
             move_num += 1
@@ -614,7 +620,12 @@ if __name__ == '__main__':
                 has_prev = True
                 analyze_tasks_initial_done += 1
 
+                # save to file results with analyzing main line
+                write_to_file(args.SGF_FILE_SAVE_TO, 'w', sgf)
+
                 refresh_pb()
+
+                # until now analyze of main line, without sub-variations
 
             else:
                 prev_stats = {}
@@ -624,7 +635,7 @@ if __name__ == '__main__':
         leela.stop()
         leela.clear_history()
 
-        # Now fill in variations for everything we need
+        # Now fill in variations for everything we need (suggested variations)
         move_num = -1
         C = sgf.cursor()
         leela.start()
@@ -654,6 +665,10 @@ if __name__ == '__main__':
 
             do_variations(C, leela, stats, move_list, board_size, next_game_move, base_dir, args)
             variations_tasks_done += 1
+
+            # save to file results with analyzing variations
+            write_to_file(args.SGF_FILE_SAVE_TO, 'w', sgf)
+
             refresh_pb()
     except:
         traceback.print_exc()
@@ -666,7 +681,7 @@ if __name__ == '__main__':
 
     pb.finish()
 
-    with open(args.SGF_FILE_SAVE_TO, 'w') as f:
-        f.write(str(sgf))
+    # Save final results into file
+    write_to_file(args.SGF_FILE_SAVE_TO, 'w', sgf)
 
     print(sgf)

--- a/sgftools/progressbar.py
+++ b/sgftools/progressbar.py
@@ -1,6 +1,6 @@
 import sys
 import datetime
-
+import time
 
 class ProgressBar(object):
     def __init__(self, min_value=0, max_value=100, width=50, frequency=1, stream=sys.stderr):
@@ -91,7 +91,7 @@ class ProgressBar(object):
         self.stream.write(
             "\r|%s| 100.00%% | Done. | Elapsed Time: %s                                             \n" % (
                 bar_str, time_remaining))
-
+        time.sleep(0.5)
 
 def self_test_1():
     pb = ProgressBar(0, 100, 50, 1)


### PR DESCRIPTION
- add write to file with python instead of command-line
- add option --num_to_show to clean-up output of variations
- add delay before print final results in console to not mix output
- updare README.md file

Script appends move sequence suggested by Leela with 3-15 length. But even with long time-settings they often quite unreasonable and excess. It become like: nodes-per-var + this 3-15 moves. It become a mess.
--nodes-per-var allow to count in depth variations and usually no need more variations than this.
With num_to_show - script will append number of moves in each variation as: nodes-per-var + num_to_show, so there won't be any non-sense sequence by 15-25 moves.

Write to file - simply allow to write result in file without console. 