### PR TITLE
Fixed LeelaZ move_list regex

### DIFF
--- a/bot_engines.py
+++ b/bot_engines.py
@@ -410,7 +410,7 @@ class LeelaCLI(BaseCLI):
 class LeelaZeroCLI(LeelaCLI):
     update_regex = r'Playouts: ([0-9]+), Win: ([0-9]+\.[0-9]+)\%, PV:(( [A-Z][0-9]+)+)'  # OK
     status_regex = r'NN eval=([0-9]+\.[0-9]+)'  # OK
-    move_regex = r'\s*([A-Z][0-9]+) -> +([0-9]+) \(V: +([0-9]+\.[0-9]+)\%\) \(N: +([0-9]+\.[0-9]+)\%\) PV: (.*)$'  # OK
+    move_regex = r'\s*([A-Z][0-9]+) -> +([0-9]+) \(V: +([0-9]+\.[0-9]+)\%\) \([^\)]*\) \(N: +([0-9]+\.[0-9]+)\%\) PV: (.*)'
     stats_regex = r'([0-9]+) visits, ([0-9]+) nodes(?:, ([0-9]+) playouts)(?:, ([0-9]+) n/s)'  # OK
     finished_regex = r'= ([A-Z][0-9]+|resign|pass)'  # OK
 
@@ -429,8 +429,11 @@ class LeelaZeroCLI(LeelaCLI):
             move_list = self.parse_move(move_list, line)
             stats = self.parse_status(stats, None, line)
 
-        stats['best'] = move_list[0]['pos']
-        stats['winrate'] = move_list[0]['winrate']
+        try:
+            stats['best'] = move_list[0]['pos']
+            stats['winrate'] = move_list[0]['winrate']
+        except (IndexError, KeyError) as e:
+            logger.warning("Analysis has no move list, index out of bounds.")
 
         stats = self.parse_finished(stats, stdout)
 


### PR DESCRIPTION
Additionally added try except around indexing of move_list should it
return empty.

Allows LeelaZ to correctly output to the user about moves which were mistakes.